### PR TITLE
feat: add WebcamInput and preview_webcam.py for FLIR-free development

### DIFF
--- a/latency_measurement/preview_webcam.py
+++ b/latency_measurement/preview_webcam.py
@@ -1,0 +1,81 @@
+"""
+preview_webcam.py
+
+Development alternative to preview_flircam.py for machines without
+a FLIR Blackfly camera. Uses a standard webcam via WebcamInput.
+
+Use this to:
+  - Verify camera positioning before calibration
+  - Test the video pipeline without FLIR hardware
+  - Debug gesture detection on any laptop
+
+Usage:
+    python latency_measurement/preview_webcam.py
+
+Controls:
+    Press 'q' to quit.
+"""
+
+import sys
+import os
+
+# Add project root to path so `video` package is importable
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import cv2
+from video.webcam_input import WebcamInput
+
+
+def main():
+    print("=" * 50)
+    print("GestureCap — Webcam Preview (no FLIR required)")
+    print("Press 'q' to quit.")
+    print("=" * 50)
+
+    cam = WebcamInput(camera_index=0, width=640, height=480, fps=30)
+
+    last_ts = None
+    fps_display = 0.0
+
+    try:
+        while True:
+            result = cam.read_frame()
+
+            if result is None:
+                print("Failed to grab frame.")
+                break
+
+            frame, ts, _ = result
+
+            # Calculate FPS from timestamp difference (mirrors preview_flircam.py)
+            if last_ts is not None:
+                dt = ts - last_ts
+                if dt > 0:
+                    fps_display = 1.0 / dt
+            last_ts = ts
+
+            # Draw the same overlay as preview_flircam.py so behaviour is consistent
+            cv2.line(frame, (0, 400), (frame.shape[1], 400), (255, 0, 0), 2)
+            cv2.putText(frame, f"TS: {ts:.3f}s", (30, 50),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 255), 2)
+            cv2.putText(frame, f"FPS: {fps_display:.1f}", (30, 100),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2)
+            cv2.putText(frame, "[WEBCAM MODE]", (30, 150),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 165, 255), 2)
+
+            cv2.imshow("GestureCap - Webcam Preview", frame)
+
+            if cv2.waitKey(1) & 0xFF == ord('q'):
+                print("Quitting preview.")
+                break
+
+    except KeyboardInterrupt:
+        pass
+
+    finally:
+        cam.cleanup()
+        cv2.destroyAllWindows()
+
+
+if __name__ == '__main__':
+    main()

--- a/test_webcam.py
+++ b/test_webcam.py
@@ -1,0 +1,17 @@
+from gesturecap2025.video.webcam_input2 import WebcamInput
+import cv2
+
+cam = WebcamInput()
+
+while True:
+    frame = cam.read()
+    if frame is None:
+        break
+
+    cv2.imshow("Webcam", frame)
+
+    if cv2.waitKey(1) & 0xFF == 27:
+        break
+
+cam.release()
+cv2.destroyAllWindows()

--- a/video/webcam_input.py
+++ b/video/webcam_input.py
@@ -1,0 +1,132 @@
+import cv2
+import numpy as np
+import logging
+import time
+from video.video_input import VideoInput
+
+logger = logging.getLogger(__name__)
+
+
+class WebcamInput(VideoInput):
+    """
+    Webcam-based video input using OpenCV (cv2.VideoCapture).
+
+    This is a drop-in replacement for Flircam for development and testing
+    on machines without a FLIR Blackfly camera. It implements the same
+    VideoInput ABC so the rest of the pipeline works unchanged.
+
+    Parameters
+    ----------
+    camera_index : int
+        Index of the webcam to open. 0 is usually the built-in webcam.
+    width : int
+        Requested frame width in pixels.
+    height : int
+        Requested frame height in pixels.
+    fps : int
+        Requested frames per second.
+
+    Usage
+    -----
+    cam = WebcamInput(camera_index=0, width=640, height=480, fps=30)
+    frame, ts, timing = cam.read_frame()
+    cam.cleanup()
+    """
+
+    def __init__(self, camera_index: int = 0,
+                 width: int = 640,
+                 height: int = 480,
+                 fps: int = 30):
+        self.camera_index = camera_index
+        self.requested_width = width
+        self.requested_height = height
+        self.requested_fps = fps
+        self._cap = None
+        # NOTE: super().__init__() must be called at the END
+        # because it calls configure() which needs self._cap ready
+        super().__init__()
+
+    def configure(self) -> None:
+        """
+        Opens the webcam and applies resolution + FPS settings.
+        Called automatically by VideoInput.__init__() via super().__init__().
+        """
+        self._cap = cv2.VideoCapture(self.camera_index)
+
+        if not self._cap.isOpened():
+            raise RuntimeError(
+                f"Could not open webcam at index {self.camera_index}. "
+                "Check that a webcam is connected and not used by another app."
+            )
+
+        self._cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.requested_width)
+        self._cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.requested_height)
+        self._cap.set(cv2.CAP_PROP_FPS, self.requested_fps)
+
+        actual_w = int(self._cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        actual_h = int(self._cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        actual_fps = self._cap.get(cv2.CAP_PROP_FPS)
+
+        logger.info(
+            f"[WebcamInput] Opened webcam {self.camera_index}: "
+            f"{actual_w}x{actual_h} @ {actual_fps:.1f} FPS"
+        )
+        print(
+            f"[WebcamInput] Opened webcam {self.camera_index}: "
+            f"{actual_w}x{actual_h} @ {actual_fps:.1f} FPS"
+        )
+
+    def read_frame(self):
+        """
+        Captures one frame from the webcam.
+
+        Returns the same 3-tuple as Flircam.read_frame() so the rest of
+        the pipeline needs zero changes when swapping camera backends.
+
+        Returns
+        -------
+        frame : np.ndarray
+            BGR image as a writable uint8 array of shape (H, W, 3).
+        ts : float
+            Timestamp in seconds (from time.perf_counter at capture moment).
+        timing : tuple of float
+            (t_frameacq, t_getts, t_frameconv) — time taken for each internal
+            step, in seconds. t_getts and t_frameconv are 0.0 for webcam
+            since there is no chunk metadata or color conversion step.
+        """
+        if self._cap is None or not self._cap.isOpened():
+            raise RuntimeError(
+                "Webcam is not open. Make sure configure() ran successfully."
+            )
+
+        t0 = time.perf_counter()
+        ret, frame = self._cap.read()
+        t1 = time.perf_counter()
+
+        if not ret or frame is None:
+            logger.warning("[WebcamInput] Failed to read frame.")
+            return None
+
+        ts = time.perf_counter()   # wall-clock timestamp in seconds
+        t2 = time.perf_counter()
+
+        # Make frame explicitly writable (mirrors Flircam behaviour)
+        frame = np.array(frame, dtype=np.uint8)
+
+        t3 = time.perf_counter()
+
+        t_frameacq = t1 - t0      # time to grab frame from hardware
+        t_getts = t2 - t1         # time to get timestamp (trivial for webcam)
+        t_frameconv = t3 - t2     # time to ensure writeable array
+
+        return frame, ts, (t_frameacq, t_getts, t_frameconv)
+
+    def cleanup(self) -> None:
+        """
+        Releases the webcam. Mirrors Flircam.cleanup() behaviour.
+        """
+        if self._cap is not None:
+            self._cap.release()
+            self._cap = None
+            logger.debug("[WebcamInput] Webcam released.")
+            print("[WebcamInput] Webcam released.")


### PR DESCRIPTION
## Summary

This PR adds webcam support to the GestureCap pipeline, as suggested by @Deepansh_Goel in the GSoC discussion channel.

The `WebcamInput` class implements the `VideoInput` ABC using OpenCV's `cv2.VideoCapture` as the camera backend, making the pipeline fully runnable on any machine without a FLIR Blackfly camera or the Spinnaker SDK.

## Changes

**`video/webcam_input.py`** (new file)
- Implements all three abstract methods: `configure()`, `read_frame()`, `cleanup()`
- `read_frame()` returns the exact same `(frame, ts, timing)` tuple as `Flircam.read_frame()` - zero changes needed in the rest of the pipeline
- Follows the same pattern as `Flircam`: `super().__init__()` called at the end of `__init__()` so `configure()` runs after camera attributes are set

**`latency_measurement/preview_webcam.py`** (new file)
- Drop-in alternative to `preview_flircam.py` for machines without FLIR hardware
- Same overlay style (timestamp, FPS, reference line) for visual consistency
- Adds a `[WEBCAM MODE]` label so it's clear which backend is running

## Testing

Tested locally:
- Webcam preview opens correctly
- FPS and timestamp overlay display as expected
- `cleanup()` releases camera on quit and on KeyboardInterrupt
- No import of PySpin anywhere in the new files